### PR TITLE
Add Hunter SE support to jazzy branch

### DIFF
--- a/hunter_base/include/hunter_base/hunter_base_ros.hpp
+++ b/hunter_base/include/hunter_base/hunter_base_ros.hpp
@@ -32,14 +32,14 @@ class HunterBaseRos : public rclcpp::Node {
   std::string odom_frame_;
   std::string base_frame_;
   std::string odom_topic_name_;
+  std::string robot_model_;
 
   bool is_hunter_mini_ = false;
   bool is_omni_wheel_ = false;
 
   bool simulated_robot_ = false;
   int sim_control_rate_ = 50;
-  
-  int version=2;
+
   bool is_omni_ = false;
   std::shared_ptr<HunterRobot> robot_;
   // std::shared_ptr<HunterMiniOmniRobot> omni_robot_;

--- a/hunter_base/include/hunter_base/hunter_params.hpp
+++ b/hunter_base/include/hunter_base/hunter_params.hpp
@@ -25,7 +25,7 @@ struct HunterV2Params {
   // from user manual v1.2.6_S P4
   // max linear velocity: 1.5 m/s
   static constexpr double max_steer_angle =
-      0.58;  // in rad, 0.75 for inner wheel
+      0.58;  // for inner wheel
   static constexpr double max_steer_angle_central =
       0.461;  // max central angle
   static constexpr double max_linear_speed = 1.5;  // in m/ss
@@ -40,7 +40,7 @@ struct HunterSEParams {
   static constexpr double transmission_reduction_rate = 30;  // 1:30
 
   static constexpr double max_steer_angle =
-      0.283;  // in rad, 0.75 for inner wheel
+      0.283;  // for inner wheel
   static constexpr double max_steer_angle_central =
       0.384;  // max central angle
   static constexpr double max_linear_speed = 1.5;  // in m/s
@@ -57,7 +57,7 @@ struct HunterV1Params {
   // from user manual v1.2.6_S P4
   // max linear velocity: 1.5 m/s
   static constexpr double max_steer_angle =
-      0.444;  // in rad, 0.75 for inner wheel
+      0.444;  // for inner wheel
   static constexpr double max_steer_angle_central =
       0.374;  // max central angle
   static constexpr double max_linear_speed = 1.5;  // in m/ss

--- a/hunter_base/include/hunter_base/hunter_params.hpp
+++ b/hunter_base/include/hunter_base/hunter_params.hpp
@@ -33,9 +33,9 @@ struct HunterV2Params {
 
 struct HunterSEParams {
   static constexpr double track =
-      0.55;  // in meter (left & right wheel distance)
+      0.52;  // in meter (left & right wheel distance)
   static constexpr double wheelbase =
-      0.52;  // in meter (front & rear wheel distance)
+      0.55;  // in meter (front & rear wheel distance)
   static constexpr double wheel_radius = 0.1375;             // in meter
   static constexpr double transmission_reduction_rate = 30;  // 1:30
 

--- a/hunter_base/include/hunter_base/hunter_params.hpp
+++ b/hunter_base/include/hunter_base/hunter_params.hpp
@@ -31,6 +31,21 @@ struct HunterV2Params {
   static constexpr double max_linear_speed = 1.5;  // in m/ss
 };
 
+struct HunterSEParams {
+  static constexpr double track =
+      0.55;  // in meter (left & right wheel distance)
+  static constexpr double wheelbase =
+      0.52;  // in meter (front & rear wheel distance)
+  static constexpr double wheel_radius = 0.1375;             // in meter
+  static constexpr double transmission_reduction_rate = 30;  // 1:30
+
+  static constexpr double max_steer_angle =
+      0.283;  // in rad, 0.75 for inner wheel
+  static constexpr double max_steer_angle_central =
+      0.384;  // max central angle
+  static constexpr double max_linear_speed = 1.5;  // in m/s
+};
+
 struct HunterV1Params {
   static constexpr double track =
       0.578;  // in meter (left & right wheel distance)

--- a/hunter_base/include/hunter_base/hunter_params.hpp
+++ b/hunter_base/include/hunter_base/hunter_params.hpp
@@ -40,9 +40,9 @@ struct HunterSEParams {
   static constexpr double transmission_reduction_rate = 30;  // 1:30
 
   static constexpr double max_steer_angle =
-      0.283;  // for inner wheel
+      0.384;  // for inner wheel
   static constexpr double max_steer_angle_central =
-      0.384;  // max central angle
+      0.283;  // max central angle
   static constexpr double max_linear_speed = 1.5;  // in m/s
 };
 

--- a/hunter_base/launch/hunter_base.launch.py
+++ b/hunter_base/launch/hunter_base.launch.py
@@ -21,6 +21,8 @@ def generate_launch_description():
                                                 description='Base link frame id')
     odom_topic_arg = DeclareLaunchArgument('odom_topic_name', default_value='odom',
                                            description='Odometry topic name')
+    robot_model_arg = DeclareLaunchArgument('robot_model', default_value='hunter2',
+                                            description='Robot model: hunter2, hunter1, hunter_se')
 
     simulated_robot_arg = DeclareLaunchArgument('simulated_robot', default_value='false',
                                                    description='Whether running with simulator')
@@ -40,6 +42,7 @@ def generate_launch_description():
                 'odom_topic_name': launch.substitutions.LaunchConfiguration('odom_topic_name'),
                 'simulated_robot': launch.substitutions.LaunchConfiguration('simulated_robot'),
                 'control_rate': launch.substitutions.LaunchConfiguration('control_rate'),
+                'robot_model': launch.substitutions.LaunchConfiguration('robot_model'),
         }])
 
     return LaunchDescription([
@@ -50,5 +53,6 @@ def generate_launch_description():
         odom_topic_arg,
         simulated_robot_arg,
         sim_control_rate_arg,
+        robot_model_arg,
         hunter_base_node
     ])

--- a/hunter_base/src/hunter_base_ros.cpp
+++ b/hunter_base/src/hunter_base_ros.cpp
@@ -20,6 +20,7 @@ HunterBaseRos::HunterBaseRos(std::string node_name)
   this->declare_parameter("odom_frame", rclcpp::ParameterValue("odom"));
   this->declare_parameter("base_frame", rclcpp::ParameterValue("base_link"));
   this->declare_parameter("odom_topic_name", rclcpp::ParameterValue("odom"));
+  this->declare_parameter("robot_model", rclcpp::ParameterValue("hunter2"));
 
   this->declare_parameter("is_hunter_mini", rclcpp::ParameterValue(false));
   this->declare_parameter("is_omni_wheel", rclcpp::ParameterValue(false));
@@ -37,8 +38,7 @@ void HunterBaseRos::LoadParameters() {
   this->get_parameter_or<std::string>("base_frame", base_frame_, "base_link");
   this->get_parameter_or<std::string>("odom_topic_name", odom_topic_name_,
                                       "odom");
-
-
+  this->get_parameter_or<std::string>("robot_model", robot_model_, "hunter2");
 
   this->get_parameter_or<bool>("simulated_robot", simulated_robot_, false);
   this->get_parameter_or<int>("control_rate", sim_control_rate_, 50);
@@ -64,12 +64,9 @@ bool HunterBaseRos::Initialize() {
     if (proto == ProtocolVersion::AGX_V1) {
       std::cout << "Detected protocol: AGX_V1" << std::endl;
       robot_ = std::unique_ptr<HunterRobot>(new HunterRobot(ProtocolVersion::AGX_V1));
-        version = 1;
     } else if (proto == ProtocolVersion::AGX_V2) {
       std::cout << "Detected protocol: AGX_V2" << std::endl;
-         robot_ = std::unique_ptr<HunterRobot>(
-              new HunterRobot(ProtocolVersion::AGX_V2));
-        version = 2;
+      robot_ = std::unique_ptr<HunterRobot>(new HunterRobot(ProtocolVersion::AGX_V2));
     } else {
       std::cout << "Detected protocol: UNKONWN" << std::endl;
       return false;
@@ -90,21 +87,21 @@ void HunterBaseRos::Run() {
         std::unique_ptr<HunterMessenger<HunterRobot>>(
             new HunterMessenger<HunterRobot>(robot_, this));
 
-    if(version==1)
-    {
+    if (robot_model_ == "hunter_se") {
+      messenger->SetTrack(HunterSEParams::track);
+      messenger->SetWeelbase(HunterSEParams::wheelbase);
+      messenger->SetMaxSteerAngleCentral(HunterSEParams::max_steer_angle_central);
+      messenger->SetMaxSteerAngle(HunterSEParams::max_steer_angle);
+    } else if (robot_model_ == "hunter1") {
       messenger->SetTrack(HunterV1Params::track);
       messenger->SetWeelbase(HunterV1Params::wheelbase);
       messenger->SetMaxSteerAngleCentral(HunterV1Params::max_steer_angle_central);
       messenger->SetMaxSteerAngle(HunterV1Params::max_steer_angle);
-
-    }
-    else
-    {
+    } else {
       messenger->SetTrack(HunterV2Params::track);
       messenger->SetWeelbase(HunterV2Params::wheelbase);
       messenger->SetMaxSteerAngleCentral(HunterV2Params::max_steer_angle_central);
       messenger->SetMaxSteerAngle(HunterV2Params::max_steer_angle);
-    
     }
     
     messenger->SetOdometryFrame(odom_frame_);


### PR DESCRIPTION
## Summary

- Add `HunterSEParams` struct with correct physical dimensions to `hunter_params.hpp`
- Add `robot_model` parameter (`hunter2` / `hunter1` / `hunter_se`) to select robot dimensions at launch
- Fix `Run()` to use `HunterSEParams` when `robot_model` is `hunter_se`
- Fix launch file to correctly pass `robot_model` argument via `LaunchConfiguration('robot_model')`

Note: The bugs reported in #24 and #25 exist in the `humble` branch and remain open. This PR resolves the equivalent issues on the `jazzy` branch.

- close #26

## Usage

```bash
# Hunter SE
ros2 launch hunter_base hunter_base.launch.py robot_model:=hunter_se

# Hunter V2 (default)
ros2 launch hunter_base hunter_base.launch.py

# Hunter V1
ros2 launch hunter_base hunter_base.launch.py robot_model:=hunter1
```